### PR TITLE
refactored workflows to use a public action

### DIFF
--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -11,7 +11,7 @@ jobs:
     name: PR has a linked issue.
     steps:
       - name: Verify Linked Issue
-        uses: hattan/verify-linked-issue-action@v1
+        uses: hattan/verify-linked-issue-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -8,13 +8,10 @@ on:
 jobs:
   verify_linked_issue:
     runs-on: ubuntu-latest
-    name: Ensure Pull Request has a linked issue.
+    name: PR has a linked issue.
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: Verify Linked Issue
-        uses: ./ 
+        uses: hattan/verify-linked-issue-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/example/verify-issue.yml
+++ b/example/verify-issue.yml
@@ -13,11 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Ensure Pull Request has a linked issue.
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: Verify Linked Issue
-        uses: ./ 
+        uses: hattan/verify-linked-issue-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/example/verify-issue.yml
+++ b/example/verify-issue.yml
@@ -14,7 +14,7 @@ jobs:
     name: Ensure Pull Request has a linked issue.
     steps:
       - name: Verify Linked Issue
-        uses: hattan/verify-linked-issue-action@v1
+        uses: hattan/verify-linked-issue-action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       


### PR DESCRIPTION
This PR updates workflows in this repo to use verify-linked-issue as a public action , rather than a private action.

Changes here also address #4 